### PR TITLE
Refactor Caching logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ them for you.
 
 ## Credits
 
-The mapping-driver interface is largely inspired on the Doctrine Common
-Persistence library. The `DefaultFileLocator` is almost an exact copy.
+This library is largely inspired on the Doctrine Common Persistence and Cache library.
 
 ## License
 

--- a/src/Cache/ArrayCache.php
+++ b/src/Cache/ArrayCache.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Cache;
+
+use Rollerworks\Component\Metadata\ClassMetadata;
+
+/**
+ * Array cache driver.
+ */
+final class ArrayCache implements ClearableCacheProvider
+{
+    /**
+     * @var array
+     */
+    private $data = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($key)
+    {
+        return isset($this->data[$key]) ? $this->data[$key] : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function contains($key)
+    {
+        return isset($this->data[$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save($key, ClassMetadata $metadata)
+    {
+        $this->data[$key] = $metadata;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($key)
+    {
+        unset($this->data[$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearAll()
+    {
+        $this->data = [];
+    }
+}

--- a/src/Cache/CacheProvider.php
+++ b/src/Cache/CacheProvider.php
@@ -14,9 +14,9 @@ namespace Rollerworks\Component\Metadata\Cache;
 use Rollerworks\Component\Metadata\ClassMetadata;
 
 /**
- * A CacheStorage manages the caching of metadata.
+ * A CacheProvider manages the caching of metadata.
  */
-interface CacheStorage
+interface CacheProvider
 {
     /**
      * Fetches a class metadata instance from the cache.

--- a/src/Cache/ChainCache.php
+++ b/src/Cache/ChainCache.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Cache;
+
+use Rollerworks\Component\Metadata\ClassMetadata;
+
+/**
+ * Cache provider that allows to easily chain multiple cache providers.
+ *
+ * @author Michaël Gallego <mic.gallego@gmail.com>
+ */
+class ChainCache implements CacheProvider, ClearableCacheProvider
+{
+    /**
+     * @var CacheProvider[]
+     */
+    private $cacheProviders = [];
+
+    /**
+     * Constructor.
+     *
+     * @param CacheProvider[] $cacheProviders
+     */
+    public function __construct($cacheProviders = [])
+    {
+        $this->cacheProviders = $cacheProviders;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($key)
+    {
+        foreach ($this->cacheProviders as $providerKey => $cacheProvider) {
+            if ($cacheProvider->contains($key)) {
+                $metadata = $cacheProvider->fetch($key);
+
+                // Populate all the previous cache layers (that are assumed to be faster).
+                for ($subKey = $providerKey - 1; $subKey >= 0; --$subKey) {
+                    $this->cacheProviders[$subKey]->save($key, $metadata);
+                }
+
+                return $metadata;
+            }
+        }
+
+        return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function contains($key)
+    {
+        foreach ($this->cacheProviders as $cacheProvider) {
+            if ($cacheProvider->contains($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save($key, ClassMetadata $metadata)
+    {
+        foreach ($this->cacheProviders as $cacheProvider) {
+            $cacheProvider->save($key, $metadata);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($key)
+    {
+        foreach ($this->cacheProviders as $cacheProvider) {
+            $cacheProvider->delete($key);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearAll()
+    {
+        foreach ($this->cacheProviders as $cacheProvider) {
+            if ($cacheProvider instanceof ClearableCacheProvider) {
+                $cacheProvider->clearAll();
+            }
+        }
+    }
+}

--- a/src/Cache/ClearableCacheProvider.php
+++ b/src/Cache/ClearableCacheProvider.php
@@ -12,10 +12,10 @@
 namespace Rollerworks\Component\Metadata\Cache;
 
 /**
- * A ClearableCacheStorage manages the caching of metadata
+ * A ClearableCacheProvider manages the caching of metadata
  * and allows to delete (clear) all the cached metadata.
  */
-interface ClearableCacheStorage extends CacheStorage
+interface ClearableCacheProvider extends CacheProvider
 {
     /**
      * Delete (clear) all the currently cached metadata.

--- a/src/CacheableMetadataFactory.php
+++ b/src/CacheableMetadataFactory.php
@@ -73,10 +73,6 @@ final class CacheableMetadataFactory implements MetadataFactory
 
         $cacheKey = str_replace('\\', '.', $className).'.single';
 
-        if (isset($this->loadedMetadata[$cacheKey])) {
-            return $this->loadedMetadata[$cacheKey];
-        }
-
         if ($this->cache->contains($cacheKey)) {
             return $this->cache->fetch($cacheKey);
         }
@@ -96,10 +92,6 @@ final class CacheableMetadataFactory implements MetadataFactory
     public function getMergedClassMetadata($className, $flags = 0)
     {
         $cacheKey = str_replace('\\', '.', $className).'.merged.'.$flags;
-
-        if (isset($this->loadedMetadata[$cacheKey])) {
-            return $this->loadedMetadata[$cacheKey];
-        }
 
         if ($this->cache->contains($cacheKey)) {
             return $this->cache->fetch($cacheKey);

--- a/src/CacheableMetadataFactory.php
+++ b/src/CacheableMetadataFactory.php
@@ -12,7 +12,7 @@
 namespace Rollerworks\Component\Metadata;
 
 use ReflectionClass;
-use Rollerworks\Component\Metadata\Cache\CacheStorage;
+use Rollerworks\Component\Metadata\Cache\CacheProvider;
 use Rollerworks\Component\Metadata\Driver\MappingDriver;
 
 final class CacheableMetadataFactory implements MetadataFactory
@@ -23,7 +23,7 @@ final class CacheableMetadataFactory implements MetadataFactory
     private $mappingDriver;
 
     /**
-     * @var CacheStorage
+     * @var CacheProvider
      */
     private $cache;
 
@@ -43,14 +43,13 @@ final class CacheableMetadataFactory implements MetadataFactory
      * Constructor.
      *
      * @param MappingDriver $mappingDriver Mapping driver used for loading metadata.
-     * @param CacheStorage  $cache         Cache storage driver for storing and loading
-     *                                     cached metadata.
+     * @param CacheProvider $cache         Cache provider for caching metadata.
      * @param callable      $classBuilder  A callback to return a new 'ClassMetadata' instance.
      *                                     Arguments: string $rootClass, array $properties, array $methods
      */
     public function __construct(
         MappingDriver $mappingDriver,
-        CacheStorage $cache,
+        CacheProvider $cache,
         callable $classBuilder = null
     ) {
         if (null === $classBuilder) {

--- a/tests/Cache/ArrayCacheTest.php
+++ b/tests/Cache/ArrayCacheTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Tests\Cache;
+
+use Rollerworks\Component\Metadata\Cache\ArrayCache;
+
+final class ArrayCacheTest extends CacheProviderTestCase
+{
+    protected function createCacheProvider()
+    {
+        return new ArrayCache();
+    }
+}

--- a/tests/Cache/CacheProviderTestCase.php
+++ b/tests/Cache/CacheProviderTestCase.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Tests\Cache;
+
+use Rollerworks\Component\Metadata\Cache\CacheProvider;
+use Rollerworks\Component\Metadata\Cache\ClearableCacheProvider;
+use Rollerworks\Component\Metadata\DefaultClassMetadata;
+
+abstract class CacheProviderTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return CacheProvider|ClearableCacheProvider
+     */
+    abstract protected function createCacheProvider();
+
+    /**
+     * @test
+     */
+    public function it_returns_null_for_missing_metadata()
+    {
+        $provider = $this->createCacheProvider();
+
+        $this->assertNull($provider->fetch('foo'));
+        $this->assertNull($provider->fetch('bar'));
+        $this->assertFalse($provider->contains('bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_save_metadata()
+    {
+        $classMetadata = new DefaultClassMetadata('stdClass');
+
+        $provider = $this->createCacheProvider();
+        $provider->save('stdClass', $classMetadata);
+
+        $this->assertEquals($classMetadata, $provider->fetch('stdClass'));
+        $this->assertEquals($classMetadata, $provider->fetch('stdClass'));
+        $this->assertTrue($provider->contains('stdClass'));
+
+        $this->assertNull($provider->fetch('bar'));
+        $this->assertFalse($provider->contains('bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_delete_stored_metadata()
+    {
+        $classMetadata = new DefaultClassMetadata('stdClass');
+
+        $provider = $this->createCacheProvider();
+        $provider->save('stdClass', $classMetadata);
+        $provider->save('stdClass2', $classMetadata);
+
+        $this->assertTrue($provider->contains('stdClass'));
+        $this->assertTrue($provider->contains('stdClass2'));
+
+        $provider->delete('stdClass');
+
+        $this->assertNull($provider->fetch('stdClass'));
+        $this->assertFalse($provider->contains('stdClass'));
+
+        $this->assertTrue($provider->contains('stdClass2'));
+        $this->assertEquals($classMetadata, $provider->fetch('stdClass2'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_clear_all_stored_metadata()
+    {
+        $provider = $this->createCacheProvider();
+
+        // Ignore when the provider doesn't support clearing.
+        // We don't skip as this functionality is not required.
+        if (!$provider instanceof ClearableCacheProvider) {
+            $this->assertTrue(true);
+        }
+
+        $classMetadata = new DefaultClassMetadata('stdClass');
+
+        $provider->save('stdClass', $classMetadata);
+        $provider->save('stdClass2', $classMetadata);
+
+        $this->assertTrue($provider->contains('stdClass'));
+        $this->assertTrue($provider->contains('stdClass2'));
+
+        $provider->clearAll();
+
+        $this->assertFalse($provider->contains('stdClass'));
+        $this->assertFalse($provider->contains('stdClass2'));
+
+        $this->assertNull($provider->fetch('stdClass'));
+        $this->assertNull($provider->fetch('stdClass2'));
+    }
+}

--- a/tests/Cache/ChainCacheTest.php
+++ b/tests/Cache/ChainCacheTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Tests\Cache;
+
+use Rollerworks\Component\Metadata\Cache\ArrayCache;
+use Rollerworks\Component\Metadata\Cache\ChainCache;
+use Rollerworks\Component\Metadata\DefaultClassMetadata;
+
+final class ChainCacheTest extends CacheProviderTestCase
+{
+    protected function createCacheProvider()
+    {
+        return new ChainCache([new ArrayCache()]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_fetch_the_first_one()
+    {
+        $classMetadata = new DefaultClassMetadata('stdClass');
+
+        $cache1 = new ArrayCache();
+        $cache2 = $this->getMockForAbstractClass('Rollerworks\Component\Metadata\Cache\CacheProvider');
+
+        $cache2->expects($this->never())->method('fetch');
+
+        $chainCache = new ChainCache([$cache1, $cache2]);
+        $chainCache->save('id', $classMetadata);
+
+        $this->assertEquals($classMetadata, $chainCache->fetch('id'));
+    }
+
+    /**
+     * @test
+     */
+    public function its_fetch_calls_are_propagate_to_the_fastest_cache()
+    {
+        $classMetadata = new DefaultClassMetadata('stdClass');
+
+        $cache1 = new ArrayCache();
+        $cache2 = new ArrayCache();
+
+        $cache2->save('bar', $classMetadata);
+
+        $chainCache = new ChainCache([$cache1, $cache2]);
+
+        $this->assertFalse($cache1->contains('bar'));
+
+        $result = $chainCache->fetch('bar');
+
+        $this->assertEquals($classMetadata, $result);
+        $this->assertTrue($cache2->contains('bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function its_delete_calls_are_propagate_to_all_providers()
+    {
+        $cache1 = $this->getMock('Rollerworks\Component\Metadata\Cache\CacheProvider');
+        $cache2 = $this->getMock('Rollerworks\Component\Metadata\Cache\CacheProvider');
+
+        $cache1->expects($this->once())->method('delete');
+        $cache2->expects($this->once())->method('delete');
+
+        $chainCache = new ChainCache([$cache1, $cache2]);
+        $chainCache->delete('bar');
+    }
+
+    /**
+     * @test
+     */
+    public function its_clearAll_calls_are_propagate_to_all_supported_providers()
+    {
+        $cache1 = $this->getMock('Rollerworks\Component\Metadata\Cache\ClearableCacheProvider');
+        $cache2 = $this->getMock('Rollerworks\Component\Metadata\Cache\ClearableCacheProvider');
+        $cache3 = $this->getMock('Rollerworks\Component\Metadata\Cache\CacheProvider');
+
+        $cache1->expects($this->once())->method('clearAll');
+        $cache2->expects($this->once())->method('clearAll');
+        // clearAll() on CacheProvider is not expected, calling it will trigger and error.
+
+        $chainCache = new ChainCache([$cache1, $cache2, $cache3]);
+        $chainCache->clearAll();
+    }
+}

--- a/tests/CacheableMetadataFactoryTest.php
+++ b/tests/CacheableMetadataFactoryTest.php
@@ -34,7 +34,7 @@ final class CacheableMetadataFactoryTest extends MetadataTestCase
     protected function setUp()
     {
         $this->driver = $this->prophesize('Rollerworks\Component\Metadata\Driver\MappingDriver');
-        $this->cache = $this->prophesize('Rollerworks\Component\Metadata\Cache\CacheStorage');
+        $this->cache = $this->prophesize('Rollerworks\Component\Metadata\Cache\CacheProvider');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | yes |
| Deprecations? | no |
| Fixed Tickets |  |
| License | MIT |

This removes the Caching logic from the `Rollerworks\Component\Metadata\CacheableMetadataFactory` and requires the usage of the `Rollerworks\Component\Metadata\Cache\ChainLoader` with the `Rollerworks\Component\Metadata\Cache\ArrayCache` instead.

Cache Storage is renamed to Cache Provider, effectively the following interfaces are renamed:
- `Rollerworks\Component\Metadata\Cache\CacheStorage` is renamed to
  `Rollerworks\Component\Metadata\Cache\CacheProvider`
- `Rollerworks\Component\Metadata\Cache\ClearableCacheStorage` is renamed to
  `Rollerworks\Component\Metadata\Cache\ClearableCacheProvider`
