### PR TITLE
Move Freshness validators to Validator namespace

### DIFF
--- a/src/Cache/ChainableFreshnessValidator.php
+++ b/src/Cache/ChainableFreshnessValidator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Cache;
+
+use Rollerworks\Component\Metadata\ClassMetadata;
+
+/**
+ * Implement this interface instead of FreshnessValidator to make
+ * the validator chainable.
+ *
+ * Each validator is checked using the accepts() method till one returns true
+ * then the freshness is checked.
+ */
+interface ChainableFreshnessValidator extends FreshnessValidator
+{
+    /**
+     * Returns whether the validator is able to validate the
+     * ClassMetadata object.
+     *
+     * @param ClassMetadata $metadata ClassMetadata implementation
+     *                                to check against.
+     *
+     * @return bool
+     */
+    public function accepts(ClassMetadata $metadata);
+}

--- a/src/Cache/Validator/AlwaysFreshValidator.php
+++ b/src/Cache/Validator/AlwaysFreshValidator.php
@@ -9,8 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Rollerworks\Component\Metadata\Cache;
+namespace Rollerworks\Component\Metadata\Cache\Validator;
 
+use Rollerworks\Component\Metadata\Cache\FreshnessValidator;
 use Rollerworks\Component\Metadata\ClassMetadata;
 
 final class AlwaysFreshValidator implements FreshnessValidator

--- a/src/Cache/Validator/ChainFreshnessValidator.php
+++ b/src/Cache/Validator/ChainFreshnessValidator.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Cache\Validator;
+
+use Rollerworks\Component\Metadata\Cache\ChainableFreshnessValidator;
+use Rollerworks\Component\Metadata\Cache\FreshnessValidator;
+use Rollerworks\Component\Metadata\ClassMetadata;
+
+final class ChainFreshnessValidator implements FreshnessValidator
+{
+    /**
+     * @var ChainableFreshnessValidator[]
+     */
+    private $validators;
+
+    /**
+     * Constructor.
+     *
+     * @param ChainableFreshnessValidator[] $validators
+     */
+    public function __construct($validators)
+    {
+        if (!is_array($validators) && !($validators instanceof \Iterator)) {
+            throw new \InvalidArgumentException('Validators is expected to an array or Iteratable object.');
+        }
+
+        $this->validators = $validators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFresh(ClassMetadata $metadata)
+    {
+        foreach ($this->validators as $validator) {
+            if ($validator->accepts($metadata)) {
+                return $validator->isFresh($metadata);
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Cache/Validator/FileTrackingValidator.php
+++ b/src/Cache/Validator/FileTrackingValidator.php
@@ -13,16 +13,27 @@ namespace Rollerworks\Component\Metadata\Cache\Validator;
 
 use Rollerworks\Component\Metadata\Cache\ChainableFreshnessValidator;
 use Rollerworks\Component\Metadata\ClassMetadata;
+use Rollerworks\Component\Metadata\FileTrackingClassMetadata;
 
-final class AlwaysFreshValidator implements ChainableFreshnessValidator
+final class FileTrackingValidator implements ChainableFreshnessValidator
 {
+    /**
+     * {@inheritdoc}
+     */
     public function isFresh(ClassMetadata $metadata)
     {
-        return true;
+        if ($metadata instanceof FileTrackingClassMetadata) {
+            return $metadata->isFresh();
+        }
+
+        return false;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function accepts(ClassMetadata $metadata)
     {
-        return true;
+        return $metadata instanceof FileTrackingClassMetadata;
     }
 }

--- a/src/FileTrackingClassMetadata.php
+++ b/src/FileTrackingClassMetadata.php
@@ -18,7 +18,7 @@ class FileTrackingClassMetadata extends DefaultClassMetadata
     /**
      * @var string[]
      */
-    private $fileResources = [];
+    protected $fileResources = [];
 
     /**
      * Constructor.

--- a/tests/Cache/Validator/ChainFreshnessValidatorTest.php
+++ b/tests/Cache/Validator/ChainFreshnessValidatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks Metadata Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Metadata\Tests\Cache\Validator;
+
+use Prophecy\Argument;
+use Rollerworks\Component\Metadata\Cache\Validator\ChainFreshnessValidator;
+use Rollerworks\Component\Metadata\DefaultClassMetadata;
+
+final class ChainFreshnessValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_false_when_no_compatible_validator_is_provided()
+    {
+        $validator1 = $this->prophesize('Rollerworks\Component\Metadata\Cache\ChainableFreshnessValidator');
+        $validator1->accepts(Argument::any())->willReturn(false);
+        $validator1->isFresh(Argument::any())->shouldNotBeCalled();
+
+        $validator2 = $this->prophesize('Rollerworks\Component\Metadata\Cache\ChainableFreshnessValidator');
+        $validator2->accepts(Argument::any())->willReturn(false);
+        $validator2->isFresh(Argument::any())->shouldNotBeCalled();
+
+        $chainValidator = new ChainFreshnessValidator([$validator1->reveal(), $validator2->reveal()]);
+
+        $this->assertFalse($chainValidator->isFresh(new DefaultClassMetadata('stdClass')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_checks_the_first_accepting_validator()
+    {
+        $validator1 = $this->prophesize('Rollerworks\Component\Metadata\Cache\ChainableFreshnessValidator');
+        $validator1->accepts(Argument::any())->willReturn(false);
+        $validator1->isFresh(Argument::any())->shouldNotBeCalled();
+
+        $validator2 = $this->prophesize('Rollerworks\Component\Metadata\Cache\ChainableFreshnessValidator');
+        $validator2->accepts(Argument::any())->willReturn(true);
+        $validator2->isFresh(Argument::any())->willReturn(true);
+
+        $validator3 = $this->prophesize('Rollerworks\Component\Metadata\Cache\ChainableFreshnessValidator');
+        $validator3->accepts(Argument::any())->shouldNotBeCalled();
+        $validator3->isFresh(Argument::any())->shouldNotBeCalled();
+
+        $chainValidator = new ChainFreshnessValidator(
+            [$validator1->reveal(), $validator2->reveal(), $validator3->reveal()]
+        );
+
+        $this->assertTrue($chainValidator->isFresh(new DefaultClassMetadata('stdClass')));
+        $this->assertTrue($chainValidator->isFresh(new DefaultClassMetadata('stdClass')));
+    }
+}

--- a/tests/Fixtures/ComplexHierarchy/InterfaceA.php
+++ b/tests/Fixtures/ComplexHierarchy/InterfaceA.php
@@ -14,5 +14,6 @@ namespace Rollerworks\Component\Metadata\Tests\Fixtures\ComplexHierarchy;
 interface InterfaceA
 {
     public function getBaz();
+
     public function getBar();
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | no |
| Deprecations? | no |
| Fixed Tickets |  |
| License | MIT |

Move Freshness validators to Validator namespace and introduce more freshness validators.
